### PR TITLE
Fix for HelpTags on Windows

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -123,7 +123,9 @@ let s:done_bundles = ''
 " Invoke :helptags on all non-$VIM doc directories in runtimepath.
 function! pathogen#helptags() " {{{1
   for dir in pathogen#split(&rtp)
-    if dir[0 : strlen($VIM)-1] !=# $VIM && isdirectory(dir.'/doc') && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))
+    "the first part of this IF was not working on windows so changed it to
+    "see if we're in a bundle dir which does work.
+    if matchstr(dir,'bundle') == 'bundle' && isdirectory(dir.'/doc') && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))
       helptags `=dir.'/doc'`
     endif
   endfor


### PR DESCRIPTION
Thanks for the awesome plugin! 

The call to HelpTags was not working on windows. After digging into the function, it looked like it was just an issue with the first check that the IF does to ensure it's not calling helptags on the standard vim dirs. I changed the first part of the IF to check in a different way and now it works on windows.

I was _not_ able to test on unix, but it should work. Also, you may have a better approach, but thought I would take a shot at helping.
