### PR TITLE
Problem in Debian like systems.

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -99,6 +99,8 @@ endfunction " }}}1
 " after the original directory.  If no argument is given, 'bundle' is used.
 " Repeated calls with the same arguments are ignored.
 function! pathogen#runtime_append_all_bundles(...) " {{{1
+  filetype off
+
   let sep = pathogen#separator()
   let name = a:0 ? a:1 : 'bundle'
   if "\n".s:done_bundles =~# "\\M\n".name."\n"


### PR DESCRIPTION
Hi Tim.

Thank you for your lot of great plugins!

I think found the problem in Debian like systems. The problem is like systemwide vimrc calls "filetype on" automatically. So I had to do it like below and it looks strange for me.

```
filetype off
call pathogen#runtime_append_all_bundles()
filetype on
```

Thank you. 

Shouichi KAMIYA
