### PR TITLE
Little fix for issue 8

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -123,7 +123,7 @@ let s:done_bundles = ''
 " Invoke :helptags on all non-$VIM doc directories in runtimepath.
 function! pathogen#helptags() " {{{1
   for dir in pathogen#split(&rtp)
-    if dir[0 : strlen($VIM)-1] !=# $VIM && isdirectory(dir.'/doc') && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))
+    if dir[0 : strlen($VIM)-1] !=# $VIM && isdirectory(dir.'/doc') && !empty(glob(dir.'/doc/*')) && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))
       helptags `=dir.'/doc'`
     endif
   endfor


### PR DESCRIPTION
Replaced line 126, i.e.

if dir[0 : strlen($VIM)-1] !=# $VIM && isdirectory(dir.'/doc') && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))

with

if dir[0 : strlen($VIM)-1] !=# $VIM && isdirectory(dir.'/doc') && !empty(glob(dir.'/doc/*')) && (!filereadable(dir.'/doc/tags') || filewritable(dir.'/doc/tags'))
