### PR TITLE
fix for bug with /after-folders of disabled plugins

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -91,12 +91,6 @@ function! pathogen#is_disabled(path) " {{{1
   return index(g:pathogen_disabled, strpart(a:path, strridx(a:path, sep)+1)) != -1
 endfunction "}}}1
 
-function! pathogen#is_disabled_after(path) " {{{1
-  "let path = substitute(a:path, ",\\=[^,]*$", "", "")
-  let path = substitute(a:path, '/after', '', '')
-  return pathogen#is_disabled(path)
-endfunction "}}}1
-
 " Prepend all subdirectories of path to the rtp, and append all 'after'
 " directories in those subdirectories.
 function! pathogen#runtime_prepend_subdirectories(path) " {{{1
@@ -124,7 +118,7 @@ function! pathogen#runtime_append_all_bundles(...) " {{{1
   let list = []
   for dir in pathogen#split(&rtp)
     if dir =~# '\<after$'
-      let list +=  filter(pathogen#glob_directories(substitute(dir,'after$',name,'').sep.'*[^~]'.sep.'after'), '!pathogen#is_disabled_after(v:val)') + [dir]
+      let list +=  filter(pathogen#glob_directories(substitute(dir,'after$',name,'').sep.'*[^~]'.sep.'after'), '!pathogen#is_disabled(v:val[0:-7])') + [dir]
     else
       let list +=  [dir] + filter(pathogen#glob_directories(dir.sep.name.sep.'*[^~]'), '!pathogen#is_disabled(v:val)')
     endif


### PR DESCRIPTION
Hi,

This weekend I started using Pathogen for my vim configuration and I really like it so far!
Because I want to disable one of my bundles based on some conditional logic, I used the g:pathogen_disabled list of pathogen, but for that specific plugin it didn't work (it's the csscolor bundle in my dotvim repo). The reason is that there seems to be a small bug in how disabled plugins are checked in case of a '/after'-folder (it checks if 'after' is in the disabled list, while it should check the bundle-name). So while the plugin was not added to the runtimepath, it's /after-folder was still added. I have modified your code so it checks for the actual bundle name instead of 'after' and this seems to work. (please note that i don't know vimscript (yet), so i might have completely misunderstood the code and/or broken everything...)

thx for the nice plugin!
Jeroen
