### PR TITLE
add pathogen#infect() as primary point of entry for basic usage

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -4,12 +4,26 @@
 
 " Install in ~/.vim/autoload (or ~\vimfiles\autoload).
 "
+" For management of individually installed plugins in ~/.vim/bundle
+" (or $HOME/vimfiles/bundle), adding 'call pathogen#infect()' to your
+" .vimrc prior to 'fileype plugin indent on' is the only other setup necessary.
+"
 " API is documented below.
 
 if exists("g:loaded_pathogen") || &cp
   finish
 endif
 let g:loaded_pathogen = 1
+
+" Point of entry for basic default usage.
+function! pathogen#infect() abort " {{{1
+  let filetype_was_on = exists('g:did_load_filetypes')
+  filetype off
+  call pathogen#runtime_append_all_bundles()
+  if filetype_was_on
+    filetype on
+  endif
+endfunction " }}}1
 
 " Split a path into a list.
 function! pathogen#split(path) abort " {{{1


### PR DESCRIPTION
The three main issues with <code>pathogen.vim</code> that I see frequently in #vim freenode, on twitter, and in blog comments are:

<ol>
    <li>people forgetting the exact name of <code>pathogen#runtime_append_all_bundles()</code>
    <li>people forgetting or not knowing about about <code>pathogen#helptags()</code> and thus wondering why there isn't help available for their <code>bundle</code>d plugins (I didn't even know there was a <code>:Helptags</code> command, too, until I was editing the file for this change) and
    <li>various cargo-cult advice about the <code>filetype on</code>/<code>filetype off</code> dance to load ftdetect files from <code>bundle</code>d plugins. By encapsulating all of the essential pathogen bits into a single, memorable function, I suspect a lot of these problems would go away.
</ol>

Granted, all of this information is available to anyone who actually reads the <a href="http://www.vim.org/scripts/script.php?script_id=2332">vim.org</a> page for the script, but I think having a two step installation process with no caveats would encourage even more people to successfully adopt <code>pathogen.vim</code>, and this could only make the world a better place.
