### PR TITLE
Update curl command in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Installation
 Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
     mkdir -p ~/.vim/autoload ~/.vim/bundle; \
-    curl -o ~/.vim/autoload/pathogen.vim \
+    curl -so ~/.vim/autoload/pathogen.vim \
         https://raw.github.com/tpope/vim-pathogen/HEAD/autoload/pathogen.vim
 
 


### PR DESCRIPTION
This pull request has absolutely nothing to do with the pathogen code. I just chained the installation commands together so that you really can just copy and paste one command.

I also removed the `>` redirection and used curl's `-o` option instead. I think this is a better approach since there's an outside possibility that the curl output could have some unwanted side-effects. I added the silent option too, `-s`, since we really don't need to see any feedback from curl. I think that's especially a good idea if you want to continue using `>` instead of `-o`.

Thanks,
Daniel
