### PR TITLE
Dot prefixed bundle support

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -150,9 +150,13 @@ function! pathogen#runtime_append_all_bundles(...) " {{{1
   let list = []
   for dir in pathogen#split(&rtp)
     if dir =~# '\<after$'
-      let list +=  filter(pathogen#glob_directories(substitute(dir,'after$',name,'').sep.'*[^~]'.sep.'after'), '!pathogen#is_disabled(v:val[0:-7])') + [dir]
+      let list +=  filter(pathogen#glob_directories(substitute(dir,'after$',name,'').sep.'.[^.]*[^~]'.sep.'after'), '!pathogen#is_disabled(v:val[0:-7])')
+      let list +=  filter(pathogen#glob_directories(substitute(dir,'after$',name,'').sep.'*[^~]'.sep.'after'), '!pathogen#is_disabled(v:val[0:-7])')
+      let list +=  [dir]
     else
-      let list +=  [dir] + filter(pathogen#glob_directories(dir.sep.name.sep.'*[^~]'), '!pathogen#is_disabled(v:val)')
+      let list +=  [dir]
+      let list +=  filter(pathogen#glob_directories(dir.sep.name.sep.'.[^.]*[^~]'), '!pathogen#is_disabled(v:val)')
+      let list +=  filter(pathogen#glob_directories(dir.sep.name.sep.'*[^~]'), '!pathogen#is_disabled(v:val)')
     endif
   endfor
   let &rtp = pathogen#join(pathogen#uniq(list))


### PR DESCRIPTION
Currently pathogen can't load bundle with dot started name. (`bundle/.dot_named_bundle`)
And this change can load dot prefixed bundles. (`bundle/.my_hidden_bundle`, `bundle/.example`, ...)

Also this change is support for ignore one and two dotted folder (other words: `.`, `..` folders).
