### PR TITLE
Added -k to curl, GitHub's SSL cert is suspect

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Installation
 Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
     mkdir -p ~/.vim/autoload ~/.vim/bundle; \
-    curl -so ~/.vim/autoload/pathogen.vim \
+    curl -kso ~/.vim/autoload/pathogen.vim \
         https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 
 If you don't have `curl`, use `wget -O -` instead.


### PR DESCRIPTION
Added the -k (aka --insecure) flag to the curl command to fetch pathogen from Github because Github's SSL cert is not signed by a trusted authority.
