### PR TITLE
fix error in pathogen#runtime_append_all_bundles

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -211,7 +211,7 @@ function! pathogen#runtime_append_all_bundles(...) abort " {{{1
   else
     call s:warn('Change pathogen#runtime_append_all_bundles() to pathogen#incubate()')
   endif
-  return call('pathogen#incubate', map(copy(a:000, 'v:val . "/{}"'))
+  return call('pathogen#incubate', map(copy(a:000),'v:val . "/{}"'))
 endfunction
 
 let s:done_bundles = ''


### PR DESCRIPTION
```
Error detected while processing function pathogen#runtime_append_all_bundles:
line    6:
E118: Too many arguments for function: copy
E116: Invalid arguments for function map(copy(a:000, 'v:val . "/{}"'))
E116: Invalid arguments for function call('pathogen#incubate', map(copy(a:000, 'v:val . "/{}"'))
E15: Invalid expression: call('pathogen#incubate', map(copy(a:000, 'v:val . "/{}"'))

```

Another typo :)
