### PR TITLE
Add --insecure option when downloading from GitHub

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ private directories.
 Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
     mkdir -p ~/.vim/autoload ~/.vim/bundle; \
-    curl -Sso ~/.vim/autoload/pathogen.vim \
+    curl -Skso ~/.vim/autoload/pathogen.vim \
         https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 
 If you're using Windows, change all occurrences of `~/.vim` to `~\vimfiles`.


### PR DESCRIPTION
Even with `-S` option `curl` failed silently.

I spent an hour before I realised that pathogen.vim was empty :(
