### PR TITLE
Tiny change: Make command more readable in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ private directories.
 
 Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
-    mkdir -p ~/.vim/autoload ~/.vim/bundle; \
+    mkdir -p ~/.vim/autoload ~/.vim/bundle
     curl -Sso ~/.vim/autoload/pathogen.vim \
         https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 


### PR DESCRIPTION
Why would you want to have these characters there?
