### PR TITLE
Better relative paths handling and returning more useful values from API

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -29,16 +29,14 @@ endfunction
 function! pathogen#infect(...) abort " {{{1
   let result =  {'before' : [], 'after' : []}
   for path in a:0 ? reverse(copy(a:000)) : ['bundle/{}']
-    if path =~# '^[^\\/]\+$'
+    if path !~# '[\\/]\%({}\|\*\)$' " Doesn't end with a mask '/{}' or '/*'
       call s:warn('Change pathogen#infect('.string(path).') to pathogen#infect('.string(path.'/{}').')')
-      let result = pathogen#incubate(path . '/{}')
-    elseif path =~# '^[^\\/]\+[\\/]\%({}\|\*\)$'
+      let path = path . '/{}'
+    endif
+    if path =~# '^[^\\/~]' " Doesn't start from slash or tilde => relative
       let result = pathogen#incubate(path)
-    elseif path =~# '[\\/]\%({}\|\*\)$'
-      let result = pathogen#surround(path)
     else
-      call s:warn('Change pathogen#infect('.string(path).') to pathogen#infect('.string(path.'/{}').')')
-      let result = pathogen#surround(path . '/{}')
+      let result = pathogen#surround(path)
     endif
   endfor
   call pathogen#cycle_filetype()

--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -213,6 +213,10 @@ function! pathogen#incubate(...) abort " {{{1
       let before += before_dir
     endif
   endfor
+  " fallback to pathogen#surround() if nothing was found in runtimepath
+  if (a:0 && (len(before) == 0) && (len(after) == 0))
+    return pathogen#surround(name)
+  endif
   let &rtp = pathogen#join(pathogen#uniq(rtp_list))
   return {'before' : pathogen#uniq(before), 'after' : pathogen#uniq(after)}
 endfunction " }}}1

--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -27,20 +27,19 @@ endfunction
 " pathogen#surround().  For backwards compatibility purposes, a full path that
 " does not end in {} or * is given to pathogen#surround().
 function! pathogen#infect(...) abort " {{{1
-  let result =  {'before' : [], 'after' : []}
   for path in a:0 ? reverse(copy(a:000)) : ['bundle/{}']
     if path !~# '[\\/]\%({}\|\*\)$' " Doesn't end with a mask '/{}' or '/*'
       call s:warn('Change pathogen#infect('.string(path).') to pathogen#infect('.string(path.'/{}').')')
       let path = path . '/{}'
     endif
     if path =~# '^[^\\/~]' " Doesn't start from slash or tilde => relative
-      let result = pathogen#incubate(path)
+      call pathogen#incubate(path)
     else
-      let result = pathogen#surround(path)
+      call pathogen#surround(path)
     endif
   endfor
   call pathogen#cycle_filetype()
-  return result
+  return ''
 endfunction " }}}1
 
 " Split a path into a list.


### PR DESCRIPTION
I'm not sure that a suggested fallback from incubate to surround will work on windows, but looks logically.

Returning path lists, that were just loaded, is very useful for plugins, that use pathogen's internal API. i.e. I've created my own vim-profiles plugin, that uses this feature. Also vim-ipi may benefit from this change, since now it is forced to make extra rtp value comparison before and after pathogen invocation to detect loaded plugins.
