### PR TITLE
Check for translated help files in doc directory

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -140,9 +140,16 @@ let s:done_bundles = {}
 function! pathogen#helptags() abort
   let sep = pathogen#slash()
   for glob in pathogen#split(&rtp)
-    for dir in map(split(glob(glob), "\n"), 'v:val.sep."/doc/".sep')
-      if (dir)[0 : strlen($VIMRUNTIME)] !=# $VIMRUNTIME.sep && filewritable(dir) == 2 && !empty(split(glob(dir.'*.txt'))) && (!filereadable(dir.'tags') || filewritable(dir.'tags'))
+    for dir in map(split(glob(glob), "\n"), 'v:val.sep."doc".sep')
+      if (dir)[0 : strlen($VIMRUNTIME)] ==# $VIMRUNTIME.sep || filewritable(dir) != 2
+        continue
+      elseif !empty(split(glob(dir.'*.txt'))) && (!filereadable(dir.'tags') || filewritable(dir.'tags'))
         silent! execute 'helptags' pathogen#fnameescape(dir)
+      elseif has('multi_lang') && !empty(split(glob(dir.'*.??x')))
+        let list = split(glob(dir.'tags-??'), "\n")
+        if empty(list) || min(map(list, 'filewritable(v:val)'))
+          silent! execute 'helptags' pathogen#fnameescape(dir)
+        endif
       endif
     endfor
   endfor


### PR DESCRIPTION
After the commit 543041b, :Helptags checks only for the English help files.

I'm using https://github.com/vim-jp/vimdoc-ja which is a project to translate the Vim help files into Japanese, it contains only the Japanese help files (*.jax). Before the commit 543041b, :Helptags generates the help tags but after that it doesn't.
