### PR TITLE
Update README to support new github raw domain

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
     mkdir -p ~/.vim/autoload ~/.vim/bundle; \
     curl -LSso ~/.vim/autoload/pathogen.vim \
-        https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
+        https://raw.githubusercontent.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 
 If you're using Windows, change all occurrences of `~/.vim` to `~\vimfiles`.
 


### PR DESCRIPTION
Github changed raw.github.com to raw.githubusercontent.com

https://developer.github.com/changes/2014-04-25-user-content-security/

This fixes the documentation in the README to reflect the change.
