### PR TITLE
Updated install commands to use && instead of ;

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ private directories.
 
 Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
 
-    mkdir -p ~/.vim/autoload ~/.vim/bundle; \
+    mkdir -p ~/.vim/autoload ~/.vim/bundle && \
     curl -LSso ~/.vim/autoload/pathogen.vim \
         https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 
@@ -31,7 +31,7 @@ Now any plugins you wish to install can be extracted to a subdirectory
 under `~/.vim/bundle`, and they will be added to the `'runtimepath'`.
 Observe:
 
-    cd ~/.vim/bundle
+    cd ~/.vim/bundle && \
     git clone git://github.com/tpope/vim-sensible.git
 
 Now [sensible.vim](https://github.com/tpope/vim-sensible) is installed.


### PR DESCRIPTION
This way, if `mkdir` or `cd` fails, it'll stop rather than continuing to download or clone in the wrong directory.
