### PR TITLE
Issue #140 - Fix for using pathogen or bundle from a Windows SMB file

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -127,6 +127,7 @@ function! pathogen#interpose(name) abort
   let s:done_bundles[name] = 1
   let list = []
   for dir in pathogen#split(&rtp)
+    let dir = substitute(dir, '^\\', '\\\\', '')
     if dir =~# '\<after$'
       let list += reverse(filter(pathogen#expand(dir[0:-6].name.sep.'after'), '!pathogen#is_disabled(v:val[0:-7])')) + [dir]
     else
@@ -134,6 +135,7 @@ function! pathogen#interpose(name) abort
     endif
   endfor
   let &rtp = pathogen#join(pathogen#uniq(list))
+  let &rtp = substitute(&rtp, '\\\\\\', '\\\\', 'g')
   return 1
 endfunction
 


### PR DESCRIPTION
I don't known if this is the best solution, but it worked for me.

If have just substitute a leading single slash after pathogen have splited runtimepath. It does all its work after that, but leaves shared paths with a leading triple slash.

So, after joined it all back, I replace the triple slash by just a double slash.
