### PR TITLE
Readme: document using vim/ as an rtp

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,11 @@ You can also pass an absolute path instead.  I keep the plugins I maintain under
 
     execute pathogen#infect('bundle/{}', '~/src/vim/bundle/{}')
 
+Some plugins have repositories structured where the vim plugin is under
+`/vim`. To support these, you can use:
+
+    execute pathogen#infect('bundle/{}', 'bundle/{}/vim')
+
 Normally to generate documentation, Vim expects you to run `:helptags`
 on each directory with documentation (e.g., `:helptags ~/.vim/doc`).
 Provided with pathogen.vim is a `:Helptags` command that does this on


### PR DESCRIPTION
Some plugins have repos that host multiple versions of the plugin, with the vim version living in `/vim` or similar. Some examples:
- http://github.com/chriskempson/tomorrow-theme/tree/master/vim
- http://github.com/rstacruz/sparkup/tree/master/vim
- https://github.com/rust-lang/rust/tree/master/src/etc/vim (gasp)

pathogen actually can support these with a bit of a hack. This documents that hack.
