### PR TITLE
Add option to blacklist plugins by pattern

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -90,9 +90,10 @@ function! pathogen#cycle_filetype() abort
 endfunction
 
 " Check if a bundle is disabled.  A bundle is considered disabled if its
-" basename or full name is included in the list g:pathogen_disabled.
+" basename or full name is included in the list g:pathogen_disabled, or if the
+" full name matches the pattern at g:pathogen_blacklist_pattern.
 function! pathogen#is_disabled(path) abort
-  if a:path =~# '\~$'
+  if a:path =~# get(g:, 'pathogen_blacklist_pattern', '\~$')
     return 1
   endif
   let sep = pathogen#slash()


### PR DESCRIPTION
Rationale: I use both neovim and vim, and symlink their directories together. This works, but since some plugins work in one editor and not the other I'd like to blacklist them based on something that's easily visible from the directory structure.
I settled on this patch, and
```
if has('nvim')
	let g:pathogen_blacklist_pattern = '\/vanilla\.'
else
	let g:pathogen_blacklist_pattern = '\/nvim\.'
end
```
in my vimrc.