### PR TITLE
Minor change in README.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,8 @@ private directories.
 
 ## Installation
 
-Install to `~/.vim/autoload/pathogen.vim`.  Or copy and paste:
+Install to `~/.vim/autoload/pathogen.vim`.
+Or copy and paste the following into your terminal/shell:
 
     mkdir -p ~/.vim/autoload ~/.vim/bundle && \
     curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim


### PR DESCRIPTION
Clarify that the commands for installation are to be copy and pasted
into the terminal and not into their ~/.vimrc or something else.

Prompted by a user in #vim asking where he should paste the commands for installation...
