### PR TITLE
Make a note for users of .dotfiles repos

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,14 +34,10 @@ Observe:
     cd ~/.vim/bundle && \
     git clone https://github.com/tpope/vim-sensible.git
     
-    # IMPORTANT: For users setting up a .dotfiles repository you must
-    # add the plugins as git submodules instead of cloning. Like,
-    git submodule add https://github.com/tpope/vim-sensible.git
-
 Now [sensible.vim](https://github.com/tpope/vim-sensible) is installed.
-If you really want to get crazy, you could set it up as a submodule in
-whatever repository you keep your dot files in.  I don't like to get
-crazy.
+
+`NOTE:` If you are using a dot files repo, you should set it up as a submodule in
+whatever repository you keep your dot files in. 
 
 If you don't like the directory name `bundle`, you can pass a runtime relative
 glob as an argument:

--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,10 @@ Observe:
 
     cd ~/.vim/bundle && \
     git clone https://github.com/tpope/vim-sensible.git
+    
+    # IMPORTANT: For users setting up a .dotfiles repository you must
+    # add the plugins as git submodules instead of cloning. Like,
+    git submodule add https://github.com/tpope/vim-sensible.git
 
 Now [sensible.vim](https://github.com/tpope/vim-sensible) is installed.
 If you really want to get crazy, you could set it up as a submodule in


### PR DESCRIPTION
When setting up a [dotfiles](https://dotfiles.github.io/) repo, it is typical for the entire contents of the `.vim` directory to be added into the `.dotfiles` git repo. Having the pathogen plugins clones as nested repositories is problematic in this case and we need to instead set them up as git submodules.