### PR TITLE
Move `:Helptags` to plugin/pathogen.vim

### DIFF
--- a/autoload/pathogen.vim
+++ b/autoload/pathogen.vim
@@ -10,10 +10,10 @@
 "
 " The API is documented inline below.
 
-if exists("g:loaded_pathogen") || &cp
+if exists("g:autoloaded_pathogen") || &cp
   finish
 endif
-let g:loaded_pathogen = 1
+let g:autoloaded_pathogen = 1
 
 " Point of entry for basic default usage.  Give a relative path to invoke
 " pathogen#interpose() or an absolute path to invoke pathogen#surround().
@@ -158,8 +158,6 @@ function! pathogen#helptags() abort
     endfor
   endfor
 endfunction
-
-command! -bar Helptags :call pathogen#helptags()
 
 " Execute the given command.  This is basically a backdoor for --remote-expr.
 function! pathogen#execute(...) abort

--- a/plugin/pathogen.vim
+++ b/plugin/pathogen.vim
@@ -1,0 +1,12 @@
+" pathogen.vim - path option manipulation
+" Maintainer:   Tim Pope <http://tpo.pe/>
+" Version:      2.4
+
+if exists("g:loaded_pathogen") || &cp
+  finish
+endif
+let g:loaded_pathogen = 1
+
+command! -bar Helptags :call pathogen#helptags()
+
+" vim: et sw=2


### PR DESCRIPTION
Enables use of the command even if `pathogen#infect()` was never called.

Fixes #205