### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,81 @@
+VIM LICENSE
+
+I)  There are no restrictions on distributing unmodified copies of
+    pathogen.vim except that they must include this license text.  You can
+    also distribute unmodified parts of pathogen.vim, likewise unrestricted
+    except that they must include this license text.  You are also allowed to
+    include executables that you made from the unmodified pathogen.vim
+    sources, plus your own usage examples and Vim scripts.
+
+II) It is allowed to distribute a modified (or extended) version of
+    pathogen.vim, including executables and/or source code, when the following
+    four conditions are met:
+    1) This license text must be included unmodified.
+    2) The modified pathogen.vim must be distributed in one of the following
+       five ways:
+       a) If you make changes to pathogen.vim yourself, you must clearly
+          describe in the distribution how to contact you.  When the
+          maintainer asks you (in any way) for a copy of the modified
+          pathogen.vim you distributed, you must make your changes, including
+          source code, available to the maintainer without fee.  The
+          maintainer reserves the right to include your changes in the
+          official version of pathogen.vim.  What the maintainer will do with
+          your changes and under what license they will be distributed is
+          negotiable.  If there has been no negotiation then this license, or
+          a later version, also applies to your changes. The current
+          maintainer is Bram Moolenaar <Bram@vim.org>.  If this changes it
+          will be announced in appropriate places (most likely vim.sf.net,
+          www.vim.org and/or comp.editors). When it is completely impossible
+          to contact the maintainer, the obligation to send him your changes
+          ceases.  Once the maintainer has confirmed that he has received your
+          changes they will not have to be sent again.
+       b) If you have received a modified pathogen.vim that was distributed as
+          mentioned under a) you are allowed to further distribute it
+          unmodified, as mentioned at I).  If you make additional changes the
+          text under a) applies to those changes.
+       c) Provide all the changes, including source code, with every copy of
+          the modified pathogen.vim you distribute.  This may be done in the
+          form of a context diff.  You can choose what license to use for new
+          code you add.  The changes and their license must not restrict
+          others from making their own changes to the official version of
+          pathogen.vim.
+       d) When you have a modified pathogen.vim which includes changes as
+          mentioned under c), you can distribute it without the source code
+          for the changes if the following three conditions are met:
+          - The license that applies to the changes permits you to distribute
+            the changes to the Vim maintainer without fee or restriction, and
+            permits the Vim maintainer to include the changes in the official
+            version of pathogen.vim without fee or restriction.
+          - You keep the changes for at least three years after last
+            distributing the corresponding modified pathogen.vim.  When the
+            maintainer or someone who you distributed the modified
+            pathogen.vim to asks you (in any way) for the changes within this
+            period, you must make them available to him.
+          - You clearly describe in the distribution how to contact you.  This
+            contact information must remain valid for at least three years
+            after last distributing the corresponding modified pathogen.vim,
+            or as long as possible.
+       e) When the GNU General Public License (GPL) applies to the changes,
+          you can distribute the modified pathogen.vim under the GNU GPL
+          version 2 or any later version.
+    3) A message must be added, at least in the output of the ":version"
+       command and in the intro screen, such that the user of the modified
+       pathogen.vim is able to see that it was modified.  When distributing as
+       mentioned under 2)e) adding the message is only required for as far as
+       this does not conflict with the license used for the changes.
+    4) The contact information as required under 2)a) and 2)d) must not be
+       removed or changed, except that the person himself can make
+       corrections.
+
+III) If you distribute a modified version of pathogen.vim, you are encouraged
+     to use the Vim license for your changes and make them available to the
+     maintainer, including the source code.  The preferred way to do this is
+     by e-mail or by uploading the files to a server and e-mailing the URL. If
+     the number of changes is small (e.g., a modified Makefile) e-mailing a
+     context diff will do.  The e-mail address to be used is
+     <maintainer@vim.org>
+
+IV)  It is not allowed to remove this license from the distribution of the
+     pathogen.vim sources, parts of it or from a modified version.  You may
+     use this license for previous pathogen.vim releases instead of the
+     license that they came with, at your option.


### PR DESCRIPTION
Hi

I am working on make GitHub recognize Vim License. I already did some [work][1] and now I am prepare to send the request to GitHub. Based on the [guide][2]. I have to provide 3 notable project using Vim License and can be detect by Licensee. I believe Vim itself should be the [first][3]. And this project, **pathogen.vim** should be the second in the list. Because:

1. pathogen.vim changed the ecosystem of Vim plugin completely;
2. This work is distribute under the same terms as Vim itself. I assume it is Vim License.

This PR adds the `LICENSE` file to the repo. Then Licensee will be able to detect it. The content of the file is generated by my [tool][4]. Based on discussion with Bram. The maintainer in the Vim License always refers to Vim Maintainer. So only project name is replaced. 

[1]:https://groups.google.com/forum/#!topic/vim_dev/DlTVMew1ZSo
[2]:https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license
[3]:https://github.com/vim/vim/pull/5458
[4]:https://othree.github.io/vim-license/